### PR TITLE
Improve handling of special characters and chapter titles

### DIFF
--- a/server/src/main/kotlin/com/vishnurajeevan/libroabs/Application.kt
+++ b/server/src/main/kotlin/com/vishnurajeevan/libroabs/Application.kt
@@ -213,7 +213,7 @@ class Run : CliktCommand("run") {
         }
       }
       .forEach { book ->
-        val targetDir = File("$mediaDir/${book.authors.first()}/${book.title}")
+        val targetDir = targetDir(book)
 
         if (!targetDir.exists()) {
           lfdLogger("downloading ${book.title}")
@@ -269,7 +269,7 @@ class Run : CliktCommand("run") {
   }
 
   private suspend fun convertBookToM4b(book: Book, overwrite: Boolean = false) {
-    val targetDir = File("$mediaDir/${book.authors.first()}/${book.title}")
+    val targetDir = targetDir(book)
     if (!targetDir.exists()) {
       lfdLogger("Book ${book.title} is not downloaded yet!")
       return
@@ -290,6 +290,11 @@ class Run : CliktCommand("run") {
       lfdLogger("Deleting obsolete mp3 files for ${book.title}")
       libroFmApi.deleteMp3Files(targetDir)
     }
+  }
+
+  private fun targetDir(book: Book): File {
+    val targetDir = File("$mediaDir/${book.authors.first()}/${book.title}")
+    return targetDir
   }
 }
 

--- a/server/src/main/kotlin/com/vishnurajeevan/libroabs/Application.kt
+++ b/server/src/main/kotlin/com/vishnurajeevan/libroabs/Application.kt
@@ -11,10 +11,7 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.int
-import com.vishnurajeevan.libroabs.libro.Book
-import com.vishnurajeevan.libroabs.libro.LibraryMetadata
-import com.vishnurajeevan.libroabs.libro.LibroApiHandler
-import com.vishnurajeevan.libroabs.libro.M4BUtil
+import com.vishnurajeevan.libroabs.libro.*
 import io.github.kevincianfarini.cardiologist.intervalPulse
 import io.ktor.client.HttpClient
 import io.ktor.server.engine.embeddedServer
@@ -22,6 +19,7 @@ import io.ktor.server.netty.Netty
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
+import io.ktor.util.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -183,7 +181,7 @@ class Run : CliktCommand("run") {
                     call.respondText("Starting conversion process for all books in the library" + if (overwrite) " and overwriting existing books" else "")
                     convertAllBooksToM4b(overwrite)
                   } else {
-                    call.respondText("Starting conversion process for $isbn"+ if (overwrite) " and overwriting existing book" else "")
+                    call.respondText("Starting conversion process for $isbn" + if (overwrite) " and overwriting existing book" else "")
                     convertBookToM4b(isbn, overwrite)
                   }
                 }

--- a/server/src/main/kotlin/com/vishnurajeevan/libroabs/libro/M4BUtil.kt
+++ b/server/src/main/kotlin/com/vishnurajeevan/libroabs/libro/M4BUtil.kt
@@ -41,7 +41,7 @@ class M4BUtil(
       bufferedWriter().use { writer ->
         chapterFiles.forEach { file ->
           if (!file.exists()) throw IllegalArgumentException("MP3 file not found: ${file.absolutePath}")
-          writer.write("file '${file.absolutePath}'\n")
+          writer.write(escapeForInputList(file.absolutePath))
         }
       }
     }
@@ -152,3 +152,6 @@ class M4BUtil(
     return TimeUnit.MILLISECONDS.convert(format.duration.toLong(), TimeUnit.SECONDS)
   }
 }
+  private fun escapeForInputList(path: String): String {
+    return "file '${path.replace("'", "'\\''")}'\n"
+  }


### PR DESCRIPTION
This fixes #59 and also improves handling of special charaters in metadata content

Additionally I fixed:
- Books now get downloaded first if they're not present/mp3 files are missing
- Chapters now don't get set to a generic "Chapter X" but instead use either a) the info provided by Libro's API or b) the title of the mp3 file and only fall back to the generic text when needed.