### PR TITLE
feat: allow for parallel downloading and processing of books

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ ENV \
     RENAME_CHAPTERS="false" \
     WRITE_TITLE_TAG="false" \
     DEV_MODE="false" \
-    SYNC_INTERVAL="d"
+    SYNC_INTERVAL="d" \
+    PARALLEL_PROCESSING_LIMIT=5 \
+    JAVA_OPTS="-Xmx4G"
 
 WORKDIR /app
 COPY scripts/run.sh ./


### PR DESCRIPTION
- Introduces a new PARALLEL_PROCESSING_LIMIT option (default: 5)
- within that limit, books are downloaded and (f needed) converted in parallel

fixes #75

So this also works if you just want to download many mp3s

NOTE: Not super familiar with Kotlin's coroutine model, so I hope this is correct. 