### PR TITLE
Change /update webhook behavior

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,8 +27,10 @@ ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "k
 ktor-client-content-negotiation= { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-html = { module = "io.ktor:ktor-server-html-builder", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
+ktor-server-content-negotiation= { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }
 ktor-server-tests = { module = "io.ktor:ktor-server-tests-jvm", version.ref = "ktor" }
+ktor-server-resources = { module = "io.ktor:ktor-server-resources", version.ref = "ktor" }
 ktor-serialization-kotlinx = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -30,7 +30,9 @@ dependencies {
   implementation(libs.ktor.html)
   implementation(libs.ktor.serialization.kotlinx)
   implementation(libs.ktor.server.core)
+  implementation(libs.ktor.server.content.negotiation)
   implementation(libs.ktor.server.netty)
+  implementation(libs.ktor.server.resources)
   implementation(libs.ktorfit.lib)
   implementation(libs.ktorfit.response)
 

--- a/server/src/main/kotlin/com/vishnurajeevan/libroabs/models/BookFormat.kt
+++ b/server/src/main/kotlin/com/vishnurajeevan/libroabs/models/BookFormat.kt
@@ -1,4 +1,4 @@
-package com.vishnurajeevan.libroabs
+package com.vishnurajeevan.libroabs.models
 
 enum class BookFormat {
   MP3,

--- a/server/src/main/kotlin/com/vishnurajeevan/libroabs/models/PathTokens.kt
+++ b/server/src/main/kotlin/com/vishnurajeevan/libroabs/models/PathTokens.kt
@@ -1,4 +1,4 @@
-package com.vishnurajeevan.libroabs
+package com.vishnurajeevan.libroabs.models
 
 import com.vishnurajeevan.libroabs.libro.Book
 

--- a/server/src/main/kotlin/com/vishnurajeevan/libroabs/models/ServerInfo.kt
+++ b/server/src/main/kotlin/com/vishnurajeevan/libroabs/models/ServerInfo.kt
@@ -1,0 +1,19 @@
+package com.vishnurajeevan.libroabs.models
+
+import com.vishnurajeevan.libroabs.ApplicationLogLevel
+import com.vishnurajeevan.libroabs.models.BookFormat
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ServerInfo(
+  val port: Int,
+  val syncInterval: String,
+  val parallelCount: Int,
+  val dryRun: Boolean,
+  val renameChapters: Boolean,
+  val writeTitleTag: Boolean,
+  val format: BookFormat,
+  val logLevel: ApplicationLogLevel,
+  val limit: Int,
+  val pathPattern: String,
+)

--- a/server/src/main/kotlin/com/vishnurajeevan/libroabs/route/Info.kt
+++ b/server/src/main/kotlin/com/vishnurajeevan/libroabs/route/Info.kt
@@ -1,0 +1,6 @@
+package com.vishnurajeevan.libroabs.route
+
+import io.ktor.resources.Resource
+
+@Resource("/info")
+class Info

--- a/server/src/main/kotlin/com/vishnurajeevan/libroabs/route/Update.kt
+++ b/server/src/main/kotlin/com/vishnurajeevan/libroabs/route/Update.kt
@@ -1,0 +1,6 @@
+package com.vishnurajeevan.libroabs.route
+
+import io.ktor.resources.Resource
+
+@Resource("/update")
+class Update(val overwrite: Boolean? = false)

--- a/server/src/test/kotlin/com/vishnurajeevan/libroabs/libro/PathTokenTest.kt
+++ b/server/src/test/kotlin/com/vishnurajeevan/libroabs/libro/PathTokenTest.kt
@@ -1,6 +1,6 @@
 package com.vishnurajeevan.libroabs.libro
 
-import com.vishnurajeevan.libroabs.createPath
+import com.vishnurajeevan.libroabs.models.createPath
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals


### PR DESCRIPTION
Changes /update to a `GET` (POST doesn't _really_ make sense anyways). Add `overwrite` query param that can force a library re-download.

Update the webpage at `/` to have a checkbox allowing you to trigger and overwrite update.

Introduce `/info` endpoint that returns info json.

Some small refactoring for file structure.

Closes #102