### PR TITLE
add custom path definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The application supports the following path tokens:
 FIRST_AUTHOR - The first author in the list of authors
 ALL_AUTHORS - All authors in the list of authors separated by ','
 SERIES_NAME - The series name, if it exists
+SERIES_NUM - The books respective series number, if it exists
 BOOK_TITLE - The book title
 ISBN - The ISBN of the book
 FIRST_NARRATOR - The first narrator in the list of narrators

--- a/server/app/src/test/kotlin/com/vishnurajeevan/libroabs/libro/PathTokenTest.kt
+++ b/server/app/src/test/kotlin/com/vishnurajeevan/libroabs/libro/PathTokenTest.kt
@@ -72,6 +72,43 @@ class PathTokenTest {
   }
 
   @Test
+  fun testCustomInputPath() {
+    val pathPattern = "MyPrefix/FIRST_AUTHOR/BOOK_TITLE"
+    val expected = "MyPrefix/Jane Doe/The Great Novel"
+    assertEquals(expected, File(singleAuthorBook.createPath(pathPattern)).path)
+  }
+
+
+  @Test
+  fun testComplexCustomInputPath() {
+    val pathPattern = "MyPrefix/FIRST_AUTHOR/SERIES_NAME/[PUBLICATION_YEAR-PUBLICATION_MONTH-PUBLICATION_DAY] BOOK_TITLE"
+    val expected = "MyPrefix/Jane Doe/Amazing Series/[2024-3-19] The Great Novel"
+    assertEquals(expected, File(singleAuthorBook.createPath(pathPattern)).path)
+  }
+
+  
+  @Test
+  fun testSeriesNum() {
+    val pathPattern = "FIRST_AUTHOR/SERIES_NAME/SERIES_NUM - BOOK_TITLE"
+    val expected = "Jane Doe/Amazing Series/1 - The Great Novel"
+    assertEquals(expected, File(singleAuthorBook.createPath(pathPattern)).path)
+  }
+
+  @Test
+  fun testNullValuesSimple() {
+    val pathPattern = "ALL_AUTHORS/SERIES_NAME/BOOK_TITLE"
+    val expected = "John Doe, Jane Smith, Alex Johnson/Collaborative Work"
+    assertEquals(expected, File(multipleAuthorsBook.createPath(pathPattern)).path)
+  }
+
+  @Test
+  fun testNullValuesComplex() {
+    val pathPattern = "ALL_AUTHORS/[SERIES_NAME - FIRST_NARRATOR] BOOK_TITLE"
+    val expected = "John Doe, Jane Smith, Alex Johnson/[ - Voice Actor] Collaborative Work"
+    assertEquals(expected, File(multipleAuthorsBook.createPath(pathPattern)).path)
+  }
+
+  @Test
   fun testAuthorAllBookTitle() {
     val pathPattern = "ALL_AUTHORS/BOOK_TITLE"
     val expected = "John Doe, Jane Smith, Alex Johnson/Collaborative Work"

--- a/server/models/src/main/kotlin/com/vishnurajeevan/libroabs/models/server/PathTokens.kt
+++ b/server/models/src/main/kotlin/com/vishnurajeevan/libroabs/models/server/PathTokens.kt
@@ -16,24 +16,36 @@ enum class PathTokens {
   PUBLICATION_YEAR,
   PUBLICATION_MONTH,
   PUBLICATION_DAY,
+  SERIES_NUM,
+}
+
+fun PathTokens.convert(book: Book): String {
+    return when(this) {
+        PathTokens.FIRST_AUTHOR -> book.authors.first().toString()
+        PathTokens.ALL_AUTHORS ->  book.authors.joinToString(", ").toString()
+        PathTokens.SERIES_NAME ->  book.series?.toString() ?: ""
+        PathTokens.BOOK_TITLE ->  book.title.toString()
+        PathTokens.ISBN ->  book.isbn.toString()
+        PathTokens.FIRST_NARRATOR ->  book.audiobook_info.narrators.first().toString()
+        PathTokens.ALL_NARRATORS ->  book.audiobook_info.narrators.joinToString(", ").toString()
+        PathTokens.PUBLICATION_YEAR ->  book.publication_date.toLocalDateTime(TimeZone.UTC).year.toString()
+        PathTokens.PUBLICATION_MONTH ->  book.publication_date.toLocalDateTime(TimeZone.UTC).month.number.toString()
+        PathTokens.PUBLICATION_DAY ->  book.publication_date.toLocalDateTime(TimeZone.UTC).dayOfMonth.toString()
+        PathTokens.SERIES_NUM -> book.series_num?.toString() ?: ""
+      }
 }
 
 fun Book.createPath(pathPattern: String): String {
-  return pathPattern.split("/")
+  return pathPattern
+    .split("/")
     .mapNotNull {
-      when(PathTokens.valueOf(it)) {
-        PathTokens.FIRST_AUTHOR -> authors.first()
-        PathTokens.ALL_AUTHORS -> authors.joinToString(", ")
-        PathTokens.SERIES_NAME -> series
-        PathTokens.BOOK_TITLE -> title
-        PathTokens.ISBN -> isbn
-        PathTokens.FIRST_NARRATOR -> audiobook_info.narrators.first()
-        PathTokens.ALL_NARRATORS -> audiobook_info.narrators.joinToString(", ")
-        PathTokens.PUBLICATION_YEAR -> publication_date.toLocalDateTime(TimeZone.UTC).year
-        PathTokens.PUBLICATION_MONTH -> publication_date.toLocalDateTime(TimeZone.UTC).month.number
-        PathTokens.PUBLICATION_DAY -> publication_date.toLocalDateTime(TimeZone.UTC).dayOfMonth
+      var pathReplace = it
+      for (token in PathTokens.entries) {
+        if (it.contains(token.toString())) {
+          pathReplace = pathReplace.replace(token.toString(), token.convert(this)) 
+        }
       }
+      pathReplace.takeIf { it != "" }
     }
     .joinToString("/")
 }
-


### PR DESCRIPTION
## Context
- I host a personal AudioBookshelf server, which auto-detects metadata using the pathing of my audio files [see their docs](https://www.audiobookshelf.org/docs#book-directory-structure).
- I find the existing pathing too constraining, particularly around usage of the date enums: `PUBLICATION_YEAR`, `PUBLICATION_MONTH`, `PUBLICATION_DAY`. I dont find the nesting here particularly useful.
- I want series number to be a pathing option. 

## Code Change
- Adds custom path definitions
  - Allows for non-variables to be added to the path pattern, which will not be replaced
  - Allows for multiple variables to be used within a single folder name
  - Fully backwards compatible
- Adds `SERIES_NUM` as option for pathing (nullable)


## Testing
- [x] Unit tests added