### PR TITLE
pull libro headers up to ENV, allowing header updates without needing to rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ ENV \
     PATH_PATTERN="FIRST_AUTHOR/BOOK_TITLE" \
     HEALTHCHECK_ID="" \
     HEALTHCHECK_HOST="https://hc-ping.com" \
+    LIBRO_FM_HEADERS="X-LibroFm-AppVer=7.34.8,User-Agent=okhttp/5.3.2" \
     HARDCOVER_TOKEN=""
 
 WORKDIR /app

--- a/server/app/src/main/kotlin/com/vishnurajeevan/libroabs/LibroDownloader.kt
+++ b/server/app/src/main/kotlin/com/vishnurajeevan/libroabs/LibroDownloader.kt
@@ -3,6 +3,7 @@ package com.vishnurajeevan.libroabs
 import com.github.ajalt.clikt.command.SuspendingCliktCommand
 import com.github.ajalt.clikt.command.main
 import com.github.ajalt.clikt.parameters.groups.cooccurring
+import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
@@ -93,6 +94,10 @@ class LibroDownloader : SuspendingCliktCommand("LibroFm Downloader") {
   private val ffprobePath by option("--ffprobe-path")
     .default("/usr/bin/ffprobe")
 
+  private val libroFmHeaders: List<String> by option("--libro-fm-headers", envvar = "LIBRO_FM_HEADERS")
+    .split(",")
+    .required()
+
   private val libroFmUsername by option("--libro-fm-username", envvar = "LIBRO_FM_USERNAME")
     .required()
 
@@ -103,6 +108,10 @@ class LibroDownloader : SuspendingCliktCommand("LibroFm Downloader") {
     val serverInfo = ServerInfo(
       libroUserName = libroFmUsername,
       libroPassword = libroFmPassword,
+      libroFmHeaders = libroFmHeaders.associate {
+        val split = it.split("=")
+        split[0] to split[1]
+      },
       port = port,
       dataDir = dataDir,
       mediaDir = mediaDir,

--- a/server/app/src/main/kotlin/com/vishnurajeevan/libroabs/graph/NetworkComponent.kt
+++ b/server/app/src/main/kotlin/com/vishnurajeevan/libroabs/graph/NetworkComponent.kt
@@ -54,12 +54,14 @@ interface NetworkComponent {
   }
 
   @Provides
-  fun libroApi(client: HttpClient): LibroAPI = Ktorfit.Builder()
+  fun libroApi(client: HttpClient, serverInfo: ServerInfo): LibroAPI = Ktorfit.Builder()
     .baseUrl("https://libro.fm/")
     .httpClient(client.config {
       defaultRequest {
         contentType(ContentType.Application.Json)
-        header("X-LibroFm-AppVer", "7.34.8")
+        serverInfo.libroFmHeaders.forEach { key, value ->
+          header(key, value)
+        }
       }
       install(ContentNegotiation) {
         json(Json {

--- a/server/models/src/main/kotlin/com/vishnurajeevan/libroabs/models/server/ServerInfo.kt
+++ b/server/models/src/main/kotlin/com/vishnurajeevan/libroabs/models/server/ServerInfo.kt
@@ -29,7 +29,8 @@ data class ServerInfo(
   val audioQuality: String,
   val skipTrackingIsbns: List<String>,
   val hardcoverSyncMode: TrackerSyncMode,
-  val webhookUrls: List<String> = emptyList()
+  val webhookUrls: List<String> = emptyList(),
+  val libroFmHeaders: Map<String, String> = emptyMap(),
 ) {
   fun prettyPrint(): String {
     return """
@@ -50,7 +51,8 @@ data class ServerInfo(
       |  Health Check ID: $healthCheckId
       |  Tracker Enabled: ${!trackerToken.isNullOrEmpty()} 
       |  Tracker sync mode: $hardcoverSyncMode
-      |  Webhook Urls: $webhookUrls
+      |  Webhook Urls: $webhookUrls,
+      |  LibroFM Headers: $libroFmHeaders
     """.trimMargin()
   }
 }


### PR DESCRIPTION
closes #291 